### PR TITLE
[Feat] Validation of Secrets pre-created in Application Namespace

### DIFF
--- a/pkg/utils/configMapUtils.go
+++ b/pkg/utils/configMapUtils.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
 	"github.com/litmuschaos/kube-helper/kubernetes/configmap"
-	volume "github.com/litmuschaos/kube-helper/kubernetes/volume/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -77,6 +76,7 @@ func CheckConfigMaps(engineDetails EngineDetails, config *rest.Config, experimen
 	}
 }
 
+// createConfigMapObject creates configMap
 func createConfigMapObject(configMap v1alpha1.ConfigMap) *corev1.ConfigMap {
 	// Create label maps
 	labels := make(map[string]string)
@@ -114,57 +114,4 @@ func CreateConfigMaps(configMaps []v1alpha1.ConfigMap, engineDetails EngineDetai
 		}
 	}
 	return err
-}
-
-/*func CreateVolumes(configMaps []v1alpha1.ConfigMap) []corev1.Volume {
-	//volumesList := make([]corev1.Volume, len(configMaps))
-	log.Infoln("-------------------------------------")
-	log.Infoln(configMaps)
-	log.Infoln("--------------------------")
-	volumesList := []corev1.Volume{}
-
-	for _, v := range configMaps {
-		log.Infoln("RETURNING OBJECT")
-		log.Infoln(v)
-		volume := corev1.Volume{}
-		volume.Name = v.Name
-		log.Infoln("!!!!!!!!!!!!!!!!!!!!!!!!!!!! ->")
-		log.Infoln(v.Name)
-		volume.ConfigMap.Name = v.Name
-		var i int = 420
-		var k int32 = int32(i)
-		volume.ConfigMap.DefaultMode = &k
-		volumesList = append(volumesList, volume)
-		//volumesList[i] = volume
-	}
-	return volumesList
-}*/
-
-// CreateVolumeBuilder build Volume needed in execution of experiments
-func CreateVolumeBuilder(configMaps []v1alpha1.ConfigMap) []*volume.Builder {
-	volumeBuilderList := []*volume.Builder{}
-	if configMaps == nil {
-		log.Infoln("Unable to fetch chaosExperiment ConfigMaps, to create volume")
-		return nil
-	}
-	for _, v := range configMaps {
-		log.Infoln("Would create VolumeBuilder for : ", v)
-		volumeBuilder := volume.NewBuilder().
-			WithConfigMap(v.Name)
-		volumeBuilderList = append(volumeBuilderList, volumeBuilder)
-	}
-	return volumeBuilderList
-}
-
-// CreateVolumeMounts mounts Volume needed in execution of experiments
-func CreateVolumeMounts(configMaps []v1alpha1.ConfigMap) []corev1.VolumeMount {
-	var volumeMountsList []corev1.VolumeMount
-	for _, v := range configMaps {
-		//volumeMount = make(corev1.VolumeMount)
-		var volumeMount corev1.VolumeMount
-		volumeMount.Name = v.Name
-		volumeMount.MountPath = v.MountPath
-		volumeMountsList = append(volumeMountsList, volumeMount)
-	}
-	return volumeMountsList
 }

--- a/pkg/utils/secretsUtils.go
+++ b/pkg/utils/secretsUtils.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	"errors"
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+// ValidateSecrets validates the secrets, before checking them.
+func ValidateSecrets(secrets []v1alpha1.Secret, engineDetails EngineDetails, clients ClientSets) ([]v1alpha1.Secret, []error) {
+	var errorList []error
+	var validSecrets []v1alpha1.Secret
+
+	for _, v := range secrets {
+		if v.Name == "" || v.MountPath == "" {
+			log.Infof("Unable to validate the Secret, with Name: %v , with mountPath: %v", v.Name, v.MountPath)
+			e := errors.New("Aborting Execution, Secret Name or mountPath is invalid")
+			errorList = append(errorList, e)
+			return nil, errorList
+		}
+
+		_, err := clients.KubeClient.CoreV1().Secrets(engineDetails.AppNamespace).Get(v.Name, metav1.GetOptions{})
+
+		if err != nil {
+			//errors = append(errors, err)
+			log.Infof("Unable to find Secret with Name: %v . Aborting Execution", v.Name)
+
+			e := errors.New("Aborting Execution, Secret not found")
+			errorList = append(errorList, e)
+			return nil, errorList
+
+		}
+
+		validSecrets = append(validSecrets, v)
+		log.Infof("Successfully Validated the Secret with Name: %v", v.Name)
+
+	}
+
+	return validSecrets, errorList
+}
+
+// CheckSecrets checks for the secrets embedded inside the chaosExperiments
+func CheckSecrets(engineDetails EngineDetails, config *rest.Config, experimentName string) (bool, []v1alpha1.Secret) {
+	_, litmusClientSet, err := GenerateClientSets(config)
+	if err != nil {
+		log.Info(err)
+	}
+	chaosExperimentObj, err := litmusClientSet.LitmuschaosV1alpha1().ChaosExperiments(engineDetails.AppNamespace).Get(experimentName, metav1.GetOptions{})
+	if err != nil {
+		log.Info(err)
+	}
+	check := chaosExperimentObj.Spec.Definition.Secrets
+	if len(check) != 0 {
+		return true, check
+	} else {
+		return false, nil
+	}
+}

--- a/pkg/utils/volumeUtils.go
+++ b/pkg/utils/volumeUtils.go
@@ -1,0 +1,60 @@
+package utils
+
+import (
+	//"errors"
+	"github.com/litmuschaos/chaos-operator/pkg/apis/litmuschaos/v1alpha1"
+	//"github.com/litmuschaos/kube-helper/kubernetes/configmap"
+	volume "github.com/litmuschaos/kube-helper/kubernetes/volume/v1alpha1"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	//metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	//"k8s.io/client-go/rest"
+)
+
+// CreateVolumeBuilder build Volume needed in execution of experiments
+func CreateVolumeBuilder(configMaps []v1alpha1.ConfigMap, secrets []v1alpha1.Secret) []*volume.Builder {
+	volumeBuilderList := []*volume.Builder{}
+	if configMaps == nil {
+		log.Infoln("Unable to fetch chaosExperiment ConfigMaps, to create volume")
+		return nil
+	}
+	for _, v := range configMaps {
+		log.Infoln("Would create VolumeBuilder for : ", v)
+		volumeBuilder := volume.NewBuilder().
+			WithConfigMap(v.Name)
+		volumeBuilderList = append(volumeBuilderList, volumeBuilder)
+	}
+
+	if secrets == nil {
+		log.Infoln("Unable to getch Valid chaosExperiment Secrets, to create Volumes")
+	}
+
+	for _, v := range secrets {
+		log.Infof("Would create VolumeBuilder for Secret Name: %v", v)
+		volumeBuilder := volume.NewBuilder().WithSecret(v.Name)
+		volumeBuilderList = append(volumeBuilderList, volumeBuilder)
+	}
+	return volumeBuilderList
+}
+
+// CreateVolumeMounts mounts Volume needed in execution of experiments
+func CreateVolumeMounts(configMaps []v1alpha1.ConfigMap, secrets []v1alpha1.Secret) []corev1.VolumeMount {
+	var volumeMountsList []corev1.VolumeMount
+	for _, v := range configMaps {
+		//volumeMount = make(corev1.VolumeMount)
+		var volumeMount corev1.VolumeMount
+		volumeMount.Name = v.Name
+		volumeMount.MountPath = v.MountPath
+		volumeMountsList = append(volumeMountsList, volumeMount)
+	}
+
+	for _, v := range secrets {
+		//volumeMount = make(corev1.VolumeMount)
+		var volumeMount corev1.VolumeMount
+		volumeMount.Name = v.Name
+		volumeMount.MountPath = v.MountPath
+		volumeMountsList = append(volumeMountsList, volumeMount)
+	}
+
+	return volumeMountsList
+}

--- a/pkg/utils/watchJob.go
+++ b/pkg/utils/watchJob.go
@@ -84,7 +84,7 @@ func UpdateResultWithJobAndDeletingJob(engineDetails EngineDetails, clients Clie
 		log.Print(err)
 		return err
 	}
-	log.Info(expEngine)
+
 	var currExpStatus v1alpha1.ExperimentStatuses
 	currExpStatus.Name = perExperiment.JobName
 	currExpStatus.Status = phase
@@ -96,7 +96,6 @@ func UpdateResultWithJobAndDeletingJob(engineDetails EngineDetails, clients Clie
 	} else {
 		expEngine.Status.Experiments[checkForjobName] = currExpStatus
 	}
-	log.Info(expEngine)
 	_, updateErr := clients.LitmusClient.LitmuschaosV1alpha1().ChaosEngines(engineDetails.AppNamespace).Update(expEngine)
 	if updateErr != nil {
 		log.Info("Updating Resource Error : ", updateErr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
- This PR, will add the ability to validate Secrets, in the application namespace, and add those into the Job created.
- Unlike ConfigMap validation, it will not create the secrets, on its own.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/litmuschaos/chaos-executor/issues/13
**Special notes for your reviewer**:

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests