### PR TITLE
[Fix(Issue#20)] chaos-executor: Fixed creation of clientSet

### DIFF
--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -50,7 +50,7 @@ type ClientSets struct {
 }
 
 // GenerateClientSets will generation both ClientSets (k8s, and Litmus)
-func (clientSets ClientSets) GenerateClientSets(config *rest.Config) error {
+func (clientSets *ClientSets) GenerateClientSets(config *rest.Config) error {
 	k8sClientSet, err := k8s.GenerateK8sClientSet(config)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Rahul M Chheda <rahul.chheda@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:
This PR is for this issue: https://github.com/litmuschaos/chaos-executor/issues/20
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Logs:
```
chaos:~$ kubectl logs -f engine-runner -n litmus
W0102 11:33:25.919087       1 client_config.go:541] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
time="2020-01-02T11:33:25Z" level=info msg="Experiments List:  [pod-delete]   Engine Name:  engine   appLabels :  app=nginx   appNamespace:  litmus   appKind:     Service Account Name:  litmus"
time="2020-01-02T11:33:25Z" level=info msg="Printing experiment.Name: pod-delete, experiment.Namespace : litmus"
time="2020-01-02T11:33:25Z" level=info msg="Going with the experiment Name: pod-delete"
time="2020-01-02T11:33:26Z" level=info msg="error while getting exp: <nil>"
time="2020-01-02T11:33:26Z" level=info msg="Experiment Found Status :  true"
time="2020-01-02T11:33:26Z" level=info msg="Getting the Default ENV Variables"
time="2020-01-02T11:33:26Z" level=info msg="Printing the Default Variablesmap[ANSIBLE_STDOUT_CALLBACK:default CHAOS_INTERVAL:5 LIB: TOTAL_CHAOS_DURATION:15]"
time="2020-01-02T11:33:26Z" level=info msg="Find the configMaps in the chaosExperiments"
time="2020-01-02T11:33:26Z" level=info msg="Succesfully Validate ConfigMap with Name: amitbhatt"
time="2020-01-02T11:33:26Z" level=info msg="Succesfully Validate ConfigMap with Name: satya"
time="2020-01-02T11:33:26Z" level=info msg="Unable to get ConfigMap with Name: rahul, in namespace: litmus"
time="2020-01-02T11:33:26Z" level=info msg="Validated ConfigMaps: [{map[] amitbhatt /mnt/} {map[] satya /mmt}]"
time="2020-01-02T11:33:26Z" level=info msg="Validated Secrets: [{rahul /mnt/var}]"
time="2020-01-02T11:33:26Z" level=info msg="Would create VolumeBuilder for :  {map[] amitbhatt /mnt/}"
time="2020-01-02T11:33:26Z" level=info msg="Would create VolumeBuilder for :  {map[] satya /mmt}"
time="2020-01-02T11:33:26Z" level=info msg="Would create VolumeBuilder for Secret Name: {rahul /mnt/var}"
time="2020-01-02T11:33:26Z" level=info msg="Patching some required ENV's"
time="2020-01-02T11:33:26Z" level=info msg="Printing the Over-ridden Variables"
time="2020-01-02T11:33:26Z" level=info msg="map[ANSIBLE_STDOUT_CALLBACK:default APP_KIND: APP_LABEL:app=nginx APP_NAMESPACE:litmus CHAOSENGINE:engine CHAOS_INTERVAL:5 LIB: TOTAL_CHAOS_DURATION:15]"
time="2020-01-02T11:33:26Z" level=info msg="Getting all the details of the experiment Name : pod-delete"
time="2020-01-02T11:33:27Z" level=info msg="Variables for ChaosJob: Experiment Labels: map[name:pod-delete], Experiment Image: litmuschaos/ansible-runner:ci, experiment.Args: [-c ansible-playbook ./experiments/generic/pod_delete/pod_delete_ansible_logic.yml -i /etc/ansible/hosts -vv; exit 0]"
time="2020-01-02T11:33:27Z" level=info msg="JobName for this Experiment : pod-delete-7cqcua"
time="2020-01-02T11:33:27Z" level=info msg="Building Pod with VolumeBuilders"
time="2020-01-02T11:33:27Z" level=info msg="Building Container with VolumeMounts"
time="2020-01-02T11:33:32Z" level=info msg="ResultName : engine-pod-delete"
time="2020-01-02T11:33:32Z" level=info msg="Patching Engine"
time="2020-01-02T11:33:32Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:33:37Z" level=info msg="Patching Engine"
time="2020-01-02T11:33:37Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:33:42Z" level=info msg="Patching Engine"
time="2020-01-02T11:33:42Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:33:47Z" level=info msg="Patching Engine"
time="2020-01-02T11:33:47Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:33:52Z" level=info msg="Patching Engine"
time="2020-01-02T11:33:52Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:33:57Z" level=info msg="Patching Engine"
time="2020-01-02T11:33:57Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:34:02Z" level=info msg="Patching Engine"
time="2020-01-02T11:34:02Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:34:07Z" level=info msg="Patching Engine"
time="2020-01-02T11:34:07Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  1"
time="2020-01-02T11:34:12Z" level=info msg="Patching Engine"
time="2020-01-02T11:34:12Z" level=info msg="Watching for Job Name : pod-delete-7cqcua status of Job :  0"
time="2020-01-02T11:34:17Z" level=info msg="Will delete the job as jobCleanPolicy is set to : delete"
```
**Checklist:**
- [ ] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests