### PR TITLE
(feat): Add auxiliaryAppInfo in go-executor

### DIFF
--- a/pkg/utils/experimentHelpers.go
+++ b/pkg/utils/experimentHelpers.go
@@ -28,6 +28,7 @@ func (expDetails *ExperimentDetails) SetENV(engineDetails EngineDetails, clients
 	expDetails.Env["APP_LABEL"] = engineDetails.AppLabel
 	expDetails.Env["APP_NAMESPACE"] = engineDetails.AppNamespace
 	expDetails.Env["APP_KIND"] = engineDetails.AppKind
+	expDetails.Env["AUXILIARY_APPINFO"] = engineDetails.AuxiliaryAppInfo
 }
 
 //SetValueFromChaosEngine sets value in experimentDetails struct from chaosEngine

--- a/pkg/utils/getOSenv.go
+++ b/pkg/utils/getOSenv.go
@@ -15,4 +15,5 @@ func GetOsEnv(engineDetails *EngineDetails) {
 	engineDetails.SvcAccount = os.Getenv("CHAOS_SVC_ACC")
 	engineDetails.ClientUUID = os.Getenv("CLIENT_UUID")
 	engineDetails.Experiments = strings.Split(experimentList, ",")
+	engineDetails.AuxiliaryAppInfo = os.Getenv("AUXILIARY_APPINFO")
 }

--- a/pkg/utils/types.go
+++ b/pkg/utils/types.go
@@ -14,13 +14,14 @@ import (
 
 // EngineDetails struct is for collecting all the engine-related details
 type EngineDetails struct {
-	Name         string
-	Experiments  []string
-	AppLabel     string
-	SvcAccount   string
-	AppKind      string
-	AppNamespace string
-	ClientUUID   string
+	Name             string
+	Experiments      []string
+	AppLabel         string
+	SvcAccount       string
+	AppKind          string
+	AppNamespace     string
+	ClientUUID       string
+	AuxiliaryAppInfo string
 }
 
 // ExperimentDetails is for collecting all the experiment-related details


### PR DESCRIPTION
Signed-off-by: shubhamchaudhary <shubham.chaudhary@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- Adding AuxiliaryAppInfo field and pass this as an ENV in chaos Job.

- The auxiliaryAppInfo contains the namespace and labels of all the dependent applications in infra-chaos experiment. Sample auxiliaryAppInfo ns1:name=percona,ns2:run=nginx

- This field is used to check the health status of all the auxiliary application in the Pre and Post chaos checks.

**Logs**
[without-auxiliaryAppinfo.txt](https://github.com/litmuschaos/chaos-executor/files/4057774/without-auxiliaryAppinfo.txt)
[withauxiliaryAppinfo.txt](https://github.com/litmuschaos/chaos-executor/files/4057775/withauxiliaryAppinfo.txt)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes litmuschaos/litmus#1112

**Special notes for your reviewer**:

**Checklist:**
- [x] Fixes #<issue number>
- [ ] Labelled this PR & related issue with `documentation` tag
- [ ] PR messages has document related information
- [ ] Labelled this PR & related issue with `breaking-changes` tag
- [ ] PR messages has breaking changes related information
- [ ] Labelled this PR & related issue with `requires-upgrade` tag
- [ ] PR messages has upgrade related information
- [ ] Commit has unit tests
- [ ] Commit has integration tests